### PR TITLE
break out required filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ exports.write = writeTile;
 exports.getLayerValues = getLayerValues;
 exports.decorateLayer = decorateLayer;
 exports.mergeLayer = mergeLayer;
+exports.filterByKeys = filterByKeys;
 
 function readTile(buf) {
     return VT.readTile(new Pbf(buf));
@@ -38,14 +39,28 @@ function getLayerValues(layer, key) {
     return values;
 }
 
-function decorateLayer(layer, keysToKeep, newProps, requiredKeys) {
+function filterByKeys(layer, requiredKeys) {
+    var keys = layer.keys;
+    var requiredLookup = {};
+    var requiredCount = (requiredKeys || []).length;
+
+    if (requiredCount) {
+        for (var i = 0; i < requiredCount; i++) {
+            requiredLookup[keys.indexOf(requiredKeys[i])] = true;
+        }
+
+        layer.features = layer.features.filter(function (feature) {
+            return hasAllKeys(feature.tags, requiredLookup, requiredCount);
+        });
+    }
+}
+
+function decorateLayer(layer, keysToKeep, newProps) {
     var keys = layer.keys;
     var values = layer.values;
     var keyLookup = {};
     var valLookup = {};
     var keepLookup = {};
-    var requiredLookup = {};
-    var requiredCount = (requiredKeys || []).length;
     var keyIndex = 0;
     var valIndex = 0;
 
@@ -54,16 +69,6 @@ function decorateLayer(layer, keysToKeep, newProps, requiredKeys) {
 
     for (var i = 0; i < keysToKeep.length; i++) {
         keepLookup[keys.indexOf(keysToKeep[i])] = true;
-    }
-
-    if (requiredCount) {
-        for (i = 0; i < requiredCount; i++) {
-            requiredLookup[keys.indexOf(requiredKeys[i])] = true;
-        }
-
-        layer.features = layer.features.filter(function (feature) {
-            return hasAllKeys(feature.tags, requiredLookup, requiredCount);
-        });
     }
 
     for (i = 0; i < layer.features.length; i++) {

--- a/index.js
+++ b/index.js
@@ -42,17 +42,15 @@ function getLayerValues(layer, key) {
 function filterByKeys(layer, requiredKeys) {
     var keys = layer.keys;
     var requiredLookup = {};
-    var requiredCount = (requiredKeys || []).length;
+    var requiredCount = requiredKeys.length;
 
-    if (requiredCount) {
-        for (var i = 0; i < requiredCount; i++) {
-            requiredLookup[keys.indexOf(requiredKeys[i])] = true;
-        }
-
-        layer.features = layer.features.filter(function (feature) {
-            return hasAllKeys(feature.tags, requiredLookup, requiredCount);
-        });
+    for (var i = 0; i < requiredCount; i++) {
+        requiredLookup[keys.indexOf(requiredKeys[i])] = true;
     }
+
+    layer.features = layer.features.filter(function (feature) {
+        return hasAllKeys(feature.tags, requiredLookup, requiredCount);
+    });
 }
 
 function decorateLayer(layer, keysToKeep, newProps) {

--- a/test/test.js
+++ b/test/test.js
@@ -117,7 +117,8 @@ test('decorateLayer filtering half of the features', function (t) {
     keys = ['id', 'type', 'color', 'foo'];
     t.deepEqual(layer.keys, keys);
     var required = ['foo'];
-    Decorator.decorateLayer(layer, keys, null, required);
+    Decorator.filterByKeys(layer, required);
+    Decorator.decorateLayer(layer, keys, null);
 
     t.equal(layer.features.length, Math.floor(featureCount / 2));
     t.equal(getAttribute(layer, layer.features[0], 'id'), 14869996);


### PR DESCRIPTION
makes filtering by keys independent - users implementing something with `TileDecorator` can choose to filter keys pre or post calling `decorateLayer`

This change is breaking